### PR TITLE
feat: /who-are-we pitch deck page

### DIFF
--- a/apps/landing/src/components/pitch/pitch-carousel.tsx
+++ b/apps/landing/src/components/pitch/pitch-carousel.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Button } from "@amaxa/ui/button";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+
+interface PitchCarouselProps {
+  children: React.ReactNode;
+  totalSlides: number;
+}
+
+export function PitchCarousel({ children, totalSlides }: PitchCarouselProps) {
+  const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleScrollToSlide = (slideIndex: number) => {
+    const isValidIndex = slideIndex >= 0 && slideIndex < totalSlides;
+    if (!isValidIndex) return;
+
+    setCurrentSlideIndex(slideIndex);
+
+    const container = scrollContainerRef.current;
+    if (container) {
+      const slideWidth = container.offsetWidth;
+      const scrollPosition = slideWidth * slideIndex;
+      container.scrollTo({ left: scrollPosition, behavior: "smooth" });
+    }
+  };
+
+  const handleNextSlide = () => handleScrollToSlide(currentSlideIndex + 1);
+  const handlePrevSlide = () => handleScrollToSlide(currentSlideIndex - 1);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const handleManualScroll = () => {
+      const slideWidth = container.offsetWidth;
+      const scrollPosition = container.scrollLeft;
+      const visibleSlideIndex = Math.round(scrollPosition / slideWidth);
+
+      const isNewSlide = visibleSlideIndex !== currentSlideIndex;
+      const isValidIndex = visibleSlideIndex >= 0 && visibleSlideIndex < totalSlides;
+
+      if (isNewSlide && isValidIndex) {
+        setCurrentSlideIndex(visibleSlideIndex);
+      }
+    };
+
+    container.addEventListener("scroll", handleManualScroll);
+    return () => container.removeEventListener("scroll", handleManualScroll);
+  }, [currentSlideIndex, totalSlides]);
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === "ArrowRight") handleNextSlide();
+      if (event.key === "ArrowLeft") handlePrevSlide();
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  });
+
+  const isFirstSlide = currentSlideIndex === 0;
+  const isLastSlide = currentSlideIndex === totalSlides - 1;
+  const currentSlideNumber = String(currentSlideIndex + 1).padStart(2, "0");
+  const totalSlidesNumber = String(totalSlides).padStart(2, "0");
+
+  return (
+    <div className="relative h-screen w-screen overflow-hidden bg-background">
+      <div
+        ref={scrollContainerRef}
+        className="flex h-full w-full overflow-x-auto snap-x snap-mandatory scrollbar-hidden"
+      >
+        {children}
+      </div>
+
+      <nav className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handlePrevSlide}
+          disabled={isFirstSlide}
+          className="h-12 w-12 rounded-full border-border bg-card/80 backdrop-blur-sm"
+          aria-label="Previous slide"
+        >
+          <IconChevronLeft className="h-5 w-5" />
+        </Button>
+
+        <div className="flex items-center gap-2 px-4">
+          {Array.from({ length: totalSlides }).map((_, index) => {
+            const isActive = index === currentSlideIndex;
+            return (
+              <button
+                key={index}
+                onClick={() => handleScrollToSlide(index)}
+                aria-label={`Go to slide ${index + 1}`}
+                className={`h-2 rounded-full transition-all ${
+                  isActive
+                    ? "w-8 bg-brand-green"
+                    : "w-2 bg-muted-foreground/40 hover:bg-muted-foreground/60"
+                }`}
+              />
+            );
+          })}
+        </div>
+
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleNextSlide}
+          disabled={isLastSlide}
+          className="h-12 w-12 rounded-full border-border bg-card/80 backdrop-blur-sm"
+          aria-label="Next slide"
+        >
+          <IconChevronRight className="h-5 w-5" />
+        </Button>
+      </nav>
+
+      <div className="fixed bottom-8 right-8 z-50 text-sm text-muted-foreground font-mono">
+        {currentSlideNumber} / {totalSlidesNumber}
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/src/components/pitch/pitch-carousel.tsx
+++ b/apps/landing/src/components/pitch/pitch-carousel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { Button } from "@amaxa/ui/button";
+import { useEffect, useRef, useState } from "react";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+
+import { Button } from "@amaxa/ui/button";
 
 interface PitchCarouselProps {
   children: React.ReactNode;
@@ -40,7 +41,8 @@ export function PitchCarousel({ children, totalSlides }: PitchCarouselProps) {
       const visibleSlideIndex = Math.round(scrollPosition / slideWidth);
 
       const isNewSlide = visibleSlideIndex !== currentSlideIndex;
-      const isValidIndex = visibleSlideIndex >= 0 && visibleSlideIndex < totalSlides;
+      const isValidIndex =
+        visibleSlideIndex >= 0 && visibleSlideIndex < totalSlides;
 
       if (isNewSlide && isValidIndex) {
         setCurrentSlideIndex(visibleSlideIndex);
@@ -67,21 +69,21 @@ export function PitchCarousel({ children, totalSlides }: PitchCarouselProps) {
   const totalSlidesNumber = String(totalSlides).padStart(2, "0");
 
   return (
-    <div className="relative h-screen w-screen overflow-hidden bg-background">
+    <div className="bg-background relative h-screen w-screen overflow-hidden">
       <div
         ref={scrollContainerRef}
-        className="flex h-full w-full overflow-x-auto snap-x snap-mandatory scrollbar-hidden"
+        className="scrollbar-hidden flex h-full w-full snap-x snap-mandatory overflow-x-auto"
       >
         {children}
       </div>
 
-      <nav className="fixed bottom-8 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4">
+      <nav className="fixed bottom-8 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4">
         <Button
           variant="outline"
           size="icon"
           onClick={handlePrevSlide}
           disabled={isFirstSlide}
-          className="h-12 w-12 rounded-full border-border bg-card/80 backdrop-blur-sm"
+          className="border-border bg-card/80 h-12 w-12 rounded-full backdrop-blur-sm"
           aria-label="Previous slide"
         >
           <IconChevronLeft className="h-5 w-5" />
@@ -97,8 +99,8 @@ export function PitchCarousel({ children, totalSlides }: PitchCarouselProps) {
                 aria-label={`Go to slide ${index + 1}`}
                 className={`h-2 rounded-full transition-all ${
                   isActive
-                    ? "w-8 bg-brand-green"
-                    : "w-2 bg-muted-foreground/40 hover:bg-muted-foreground/60"
+                    ? "bg-brand-green w-8"
+                    : "bg-muted-foreground/40 hover:bg-muted-foreground/60 w-2"
                 }`}
               />
             );
@@ -110,14 +112,14 @@ export function PitchCarousel({ children, totalSlides }: PitchCarouselProps) {
           size="icon"
           onClick={handleNextSlide}
           disabled={isLastSlide}
-          className="h-12 w-12 rounded-full border-border bg-card/80 backdrop-blur-sm"
+          className="border-border bg-card/80 h-12 w-12 rounded-full backdrop-blur-sm"
           aria-label="Next slide"
         >
           <IconChevronRight className="h-5 w-5" />
         </Button>
       </nav>
 
-      <div className="fixed bottom-8 right-8 z-50 text-sm text-muted-foreground font-mono">
+      <div className="text-muted-foreground fixed right-8 bottom-8 z-50 font-mono text-sm">
         {currentSlideNumber} / {totalSlidesNumber}
       </div>
     </div>

--- a/apps/landing/src/components/pitch/pitch-slide.astro
+++ b/apps/landing/src/components/pitch/pitch-slide.astro
@@ -1,0 +1,27 @@
+---
+interface Props {
+  id: string;
+  title: string;
+  centered?: boolean;
+}
+
+const { id, title, centered = false } = Astro.props;
+---
+
+<section
+  class="min-h-screen min-w-full w-screen flex-shrink-0 snap-start snap-always relative flex flex-col p-6 md:p-8 lg:px-12 z-[2]"
+  id={id}
+>
+  <div class="flex justify-between items-center text-sm text-muted-foreground mb-8">
+    <span>{title}</span>
+    <span class="font-medium text-brand-green">ámaxa</span>
+  </div>
+  <div
+    class:list={[
+      "flex-1 flex flex-col justify-center max-w-[1400px] mx-auto w-full pb-24",
+      { "items-center text-center": centered },
+    ]}
+  >
+    <slot />
+  </div>
+</section>

--- a/apps/landing/src/components/pitch/pitch-slide.astro
+++ b/apps/landing/src/components/pitch/pitch-slide.astro
@@ -9,16 +9,18 @@ const { id, title, centered = false } = Astro.props;
 ---
 
 <section
-  class="min-h-screen min-w-full w-screen flex-shrink-0 snap-start snap-always relative flex flex-col p-6 md:p-8 lg:px-12 z-[2]"
+  class="relative z-[2] flex min-h-screen w-screen min-w-full flex-shrink-0 snap-start snap-always flex-col p-6 md:p-8 lg:px-12"
   id={id}
 >
-  <div class="flex justify-between items-center text-sm text-muted-foreground mb-8">
+  <div
+    class="text-muted-foreground mb-8 flex items-center justify-between text-sm"
+  >
     <span>{title}</span>
-    <span class="font-medium text-brand-green">ámaxa</span>
+    <span class="text-brand-green font-medium">ámaxa</span>
   </div>
   <div
     class:list={[
-      "flex-1 flex flex-col justify-center max-w-[1400px] mx-auto w-full pb-24",
+      "mx-auto flex w-full max-w-[1400px] flex-1 flex-col justify-center pb-24",
       { "items-center text-center": centered },
     ]}
   >

--- a/apps/landing/src/components/pitch/slides/slide-partners.astro
+++ b/apps/landing/src/components/pitch/slides/slide-partners.astro
@@ -15,13 +15,16 @@ const initiatives = [
   "Climate Action",
   "Grassroots Art",
 ];
+
+const totalPartners = 9;
+const regionCount = partners.length;
 ---
 
 <PitchSlide id="partners" title="Our Partners" centered>
   <h2
     class="text-foreground mb-4 max-w-3xl text-2xl leading-tight font-bold sm:text-3xl md:text-4xl lg:text-5xl"
   >
-    9 nonprofit partners across 5 regions.
+    {totalPartners} nonprofit partners across {regionCount} regions.
   </h2>
   <p class="text-muted-foreground mb-12 max-w-2xl text-lg sm:text-xl">
     Real impact in communities that need it most.

--- a/apps/landing/src/components/pitch/slides/slide-partners.astro
+++ b/apps/landing/src/components/pitch/slides/slide-partners.astro
@@ -1,0 +1,48 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const partners = [
+  { region: "West Bank", focus: "Education" },
+  { region: "Uganda", focus: "Education" },
+  { region: "Liberia", focus: "Education" },
+  { region: "Gaza", focus: "Humanitarian Aid" },
+  { region: "Ukraine", focus: "Humanitarian Aid" },
+];
+
+const initiatives = [
+  "Mental Health First Aid",
+  "Fighting Book Bans",
+  "Climate Action",
+  "Grassroots Art",
+];
+---
+
+<PitchSlide id="partners" title="Our Partners" centered>
+  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-4 max-w-3xl">
+    9 nonprofit partners across 5 regions.
+  </h2>
+  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-2xl">
+    Real impact in communities that need it most.
+  </p>
+  
+  <div class="flex flex-wrap justify-center gap-3 mb-12 max-w-3xl">
+    {partners.map((partner) => (
+      <div class="flex items-center gap-2 bg-muted/30 border border-border/50 rounded-full px-4 py-2">
+        <span class="w-2 h-2 rounded-full bg-brand-green"></span>
+        <span class="text-sm font-medium text-foreground">{partner.region}</span>
+        <span class="text-xs text-muted-foreground">· {partner.focus}</span>
+      </div>
+    ))}
+  </div>
+
+  <div class="border-t border-border/50 pt-8 max-w-2xl">
+    <p class="text-sm text-muted-foreground uppercase tracking-wider mb-4">Original Ámaxa Initiatives</p>
+    <div class="flex flex-wrap justify-center gap-2">
+      {initiatives.map((initiative) => (
+        <span class="text-sm font-medium text-foreground bg-brand-green/10 border border-brand-green/20 rounded-full px-4 py-1.5">
+          {initiative}
+        </span>
+      ))}
+    </div>
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-partners.astro
+++ b/apps/landing/src/components/pitch/slides/slide-partners.astro
@@ -18,31 +18,41 @@ const initiatives = [
 ---
 
 <PitchSlide id="partners" title="Our Partners" centered>
-  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-4 max-w-3xl">
+  <h2
+    class="text-foreground mb-4 max-w-3xl text-2xl leading-tight font-bold sm:text-3xl md:text-4xl lg:text-5xl"
+  >
     9 nonprofit partners across 5 regions.
   </h2>
-  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-2xl">
+  <p class="text-muted-foreground mb-12 max-w-2xl text-lg sm:text-xl">
     Real impact in communities that need it most.
   </p>
-  
-  <div class="flex flex-wrap justify-center gap-3 mb-12 max-w-3xl">
-    {partners.map((partner) => (
-      <div class="flex items-center gap-2 bg-muted/30 border border-border/50 rounded-full px-4 py-2">
-        <span class="w-2 h-2 rounded-full bg-brand-green"></span>
-        <span class="text-sm font-medium text-foreground">{partner.region}</span>
-        <span class="text-xs text-muted-foreground">· {partner.focus}</span>
-      </div>
-    ))}
+
+  <div class="mb-12 flex max-w-3xl flex-wrap justify-center gap-3">
+    {
+      partners.map((partner) => (
+        <div class="bg-muted/30 border-border/50 flex items-center gap-2 rounded-full border px-4 py-2">
+          <span class="bg-brand-green h-2 w-2 rounded-full" />
+          <span class="text-foreground text-sm font-medium">
+            {partner.region}
+          </span>
+          <span class="text-muted-foreground text-xs">· {partner.focus}</span>
+        </div>
+      ))
+    }
   </div>
 
-  <div class="border-t border-border/50 pt-8 max-w-2xl">
-    <p class="text-sm text-muted-foreground uppercase tracking-wider mb-4">Original Ámaxa Initiatives</p>
+  <div class="border-border/50 max-w-2xl border-t pt-8">
+    <p class="text-muted-foreground mb-4 text-sm tracking-wider uppercase">
+      Original Ámaxa Initiatives
+    </p>
     <div class="flex flex-wrap justify-center gap-2">
-      {initiatives.map((initiative) => (
-        <span class="text-sm font-medium text-foreground bg-brand-green/10 border border-brand-green/20 rounded-full px-4 py-1.5">
-          {initiative}
-        </span>
-      ))}
+      {
+        initiatives.map((initiative) => (
+          <span class="text-foreground bg-brand-green/10 border-brand-green/20 rounded-full border px-4 py-1.5 text-sm font-medium">
+            {initiative}
+          </span>
+        ))
+      }
     </div>
   </div>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-problem.astro
+++ b/apps/landing/src/components/pitch/slides/slide-problem.astro
@@ -1,0 +1,51 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const barriers = [
+  {
+    icon: "🧭",
+    title: "I don't know how to start.",
+    quote: "There's so many problems—how do I know who to volunteer with?",
+  },
+  {
+    icon: "💭",
+    title: "I feel like I'm not making a real impact.",
+    quote: "The last time I volunteered I felt like I didn't actually make an impact.",
+  },
+  {
+    icon: "🎒",
+    title: "I'm in high school.",
+    quote: "Nonprofits ghost me—they don't take me seriously because of my age.",
+  },
+  {
+    icon: "🤝",
+    title: "I feel alone.",
+    quote: "I would love to do something, but who is going to help me?",
+  },
+  {
+    icon: "📍",
+    title: "No passionate groups in my area.",
+    quote: "There are no groups I'm truly passionate about in my area.",
+  },
+  {
+    icon: "⏰",
+    title: "Doesn't fit my schedule.",
+    quote: "The only nonprofit I like has meetings only during the workday.",
+  },
+];
+---
+
+<PitchSlide id="problem" title="The Problem">
+  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-12 max-w-3xl text-center mx-auto">
+    "I wish I could help, but what can I do?"
+  </h2>
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+    {barriers.map((barrier) => (
+      <div class="group relative bg-gradient-to-br from-muted/50 to-muted/20 border border-border/50 rounded-2xl p-6 hover:border-brand-green/50 transition-all duration-300">
+        <span class="text-3xl mb-4 block">{barrier.icon}</span>
+        <h3 class="text-lg font-semibold text-foreground mb-2">{barrier.title}</h3>
+        <p class="text-sm text-muted-foreground leading-relaxed italic">"{barrier.quote}"</p>
+      </div>
+    ))}
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-problem.astro
+++ b/apps/landing/src/components/pitch/slides/slide-problem.astro
@@ -10,12 +10,14 @@ const barriers = [
   {
     icon: "💭",
     title: "I feel like I'm not making a real impact.",
-    quote: "The last time I volunteered I felt like I didn't actually make an impact.",
+    quote:
+      "The last time I volunteered I felt like I didn't actually make an impact.",
   },
   {
     icon: "🎒",
     title: "I'm in high school.",
-    quote: "Nonprofits ghost me—they don't take me seriously because of my age.",
+    quote:
+      "Nonprofits ghost me—they don't take me seriously because of my age.",
   },
   {
     icon: "🤝",
@@ -36,16 +38,24 @@ const barriers = [
 ---
 
 <PitchSlide id="problem" title="The Problem">
-  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-12 max-w-3xl text-center mx-auto">
+  <h2
+    class="text-foreground mx-auto mb-12 max-w-3xl text-center text-2xl leading-tight font-bold sm:text-3xl md:text-4xl lg:text-5xl"
+  >
     "I wish I could help, but what can I do?"
   </h2>
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-    {barriers.map((barrier) => (
-      <div class="group relative bg-gradient-to-br from-muted/50 to-muted/20 border border-border/50 rounded-2xl p-6 hover:border-brand-green/50 transition-all duration-300">
-        <span class="text-3xl mb-4 block">{barrier.icon}</span>
-        <h3 class="text-lg font-semibold text-foreground mb-2">{barrier.title}</h3>
-        <p class="text-sm text-muted-foreground leading-relaxed italic">"{barrier.quote}"</p>
-      </div>
-    ))}
+  <div class="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+    {
+      barriers.map((barrier) => (
+        <div class="group from-muted/50 to-muted/20 border-border/50 hover:border-brand-green/50 relative rounded-2xl border bg-gradient-to-br p-6 transition-all duration-300">
+          <span class="mb-4 block text-3xl">{barrier.icon}</span>
+          <h3 class="text-foreground mb-2 text-lg font-semibold">
+            {barrier.title}
+          </h3>
+          <p class="text-muted-foreground text-sm leading-relaxed italic">
+            "{barrier.quote}"
+          </p>
+        </div>
+      ))
+    }
   </div>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-solution.astro
+++ b/apps/landing/src/components/pitch/slides/slide-solution.astro
@@ -26,23 +26,37 @@ const features = [
 ---
 
 <PitchSlide id="solution" title="Our Solution" centered>
-  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-4 max-w-3xl">
+  <h2
+    class="text-foreground mb-4 max-w-3xl text-2xl leading-tight font-bold sm:text-3xl md:text-4xl lg:text-5xl"
+  >
     A free, fully remote program for high school students.
   </h2>
-  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-2xl">
+  <p class="text-muted-foreground mb-12 max-w-2xl text-lg sm:text-xl">
     Everything you need to make a real difference.
   </p>
-  <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full max-w-4xl mb-12">
-    {features.map((feature) => (
-      <div class="bg-muted/30 border border-border/50 rounded-2xl p-5 text-center hover:border-brand-green/50 transition-colors">
-        <span class="text-3xl md:text-4xl block mb-3">{feature.icon}</span>
-        <h3 class="text-sm md:text-base font-semibold text-foreground mb-1">{feature.title}</h3>
-        <p class="text-xs md:text-sm text-muted-foreground">{feature.description}</p>
-      </div>
-    ))}
+  <div
+    class="mb-12 grid w-full max-w-4xl grid-cols-2 gap-4 md:gap-6 lg:grid-cols-4"
+  >
+    {
+      features.map((feature) => (
+        <div class="bg-muted/30 border-border/50 hover:border-brand-green/50 rounded-2xl border p-5 text-center transition-colors">
+          <span class="mb-3 block text-3xl md:text-4xl">{feature.icon}</span>
+          <h3 class="text-foreground mb-1 text-sm font-semibold md:text-base">
+            {feature.title}
+          </h3>
+          <p class="text-muted-foreground text-xs md:text-sm">
+            {feature.description}
+          </p>
+        </div>
+      ))
+    }
   </div>
-  <div class="inline-flex items-center gap-2 bg-brand-green/10 border border-brand-green/30 rounded-full px-6 py-3">
+  <div
+    class="bg-brand-green/10 border-brand-green/30 inline-flex items-center gap-2 rounded-full border px-6 py-3"
+  >
     <span class="text-brand-green font-semibold">Coming 2026:</span>
-    <span class="text-muted-foreground">Pathways for university students & professionals</span>
+    <span class="text-muted-foreground"
+      >Pathways for university students & professionals</span
+    >
   </div>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-solution.astro
+++ b/apps/landing/src/components/pitch/slides/slide-solution.astro
@@ -1,0 +1,48 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const features = [
+  {
+    icon: "🌍",
+    title: "Peers around the globe",
+    description: "Connect with passionate changemakers worldwide",
+  },
+  {
+    icon: "🎓",
+    title: "Trained undergraduate coach",
+    description: "Guidance from experienced mentors",
+  },
+  {
+    icon: "📊",
+    title: "Project management training",
+    description: "Real skills for real-world impact",
+  },
+  {
+    icon: "💻",
+    title: "Custom online platform",
+    description: "Tools to bring projects to life",
+  },
+];
+---
+
+<PitchSlide id="solution" title="Our Solution" centered>
+  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-4 max-w-3xl">
+    A free, fully remote program for high school students.
+  </h2>
+  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-2xl">
+    Everything you need to make a real difference.
+  </p>
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6 w-full max-w-4xl mb-12">
+    {features.map((feature) => (
+      <div class="bg-muted/30 border border-border/50 rounded-2xl p-5 text-center hover:border-brand-green/50 transition-colors">
+        <span class="text-3xl md:text-4xl block mb-3">{feature.icon}</span>
+        <h3 class="text-sm md:text-base font-semibold text-foreground mb-1">{feature.title}</h3>
+        <p class="text-xs md:text-sm text-muted-foreground">{feature.description}</p>
+      </div>
+    ))}
+  </div>
+  <div class="inline-flex items-center gap-2 bg-brand-green/10 border border-brand-green/30 rounded-full px-6 py-3">
+    <span class="text-brand-green font-semibold">Coming 2026:</span>
+    <span class="text-muted-foreground">Pathways for university students & professionals</span>
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-start.astro
+++ b/apps/landing/src/components/pitch/slides/slide-start.astro
@@ -4,31 +4,52 @@ import PitchSlide from "../pitch-slide.astro";
 
 <PitchSlide id="start" title="Pitch / 2025" centered>
   <div class="mb-12">
-    <svg class="w-[150px] h-[150px] md:w-[200px] md:h-[200px]" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="100" cy="100" r="98" fill="#000" stroke="#333" stroke-width="2"/>
+    <svg
+      class="h-[150px] w-[150px] md:h-[200px] md:w-[200px]"
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="100"
+        cy="100"
+        r="98"
+        fill="#000"
+        stroke="#333"
+        stroke-width="2"></circle>
       <g stroke="#fff" stroke-width="1.5" stroke-linecap="round">
-        <line x1="35" y1="95" x2="55" y2="75"/>
-        <line x1="55" y1="75" x2="50" y2="50"/>
-        <line x1="50" y1="50" x2="75" y2="40"/>
-        <line x1="75" y1="40" x2="105" y2="35"/>
-        <line x1="105" y1="35" x2="135" y2="45"/>
-        <line x1="135" y1="45" x2="160" y2="55"/>
-        <line x1="160" y1="55" x2="165" y2="80"/>
+        <line x1="35" y1="95" x2="55" y2="75"></line>
+        <line x1="55" y1="75" x2="50" y2="50"></line>
+        <line x1="50" y1="50" x2="75" y2="40"></line>
+        <line x1="75" y1="40" x2="105" y2="35"></line>
+        <line x1="105" y1="35" x2="135" y2="45"></line>
+        <line x1="135" y1="45" x2="160" y2="55"></line>
+        <line x1="160" y1="55" x2="165" y2="80"></line>
       </g>
       <g fill="#fff">
-        <circle cx="35" cy="95" r="3"/>
-        <circle cx="55" cy="75" r="3"/>
-        <circle cx="50" cy="50" r="3"/>
-        <circle cx="75" cy="40" r="3"/>
-        <circle cx="105" cy="35" r="3"/>
-        <circle cx="135" cy="45" r="3"/>
-        <circle cx="160" cy="55" r="3"/>
-        <circle cx="165" cy="80" r="3"/>
+        <circle cx="35" cy="95" r="3"></circle>
+        <circle cx="55" cy="75" r="3"></circle>
+        <circle cx="50" cy="50" r="3"></circle>
+        <circle cx="75" cy="40" r="3"></circle>
+        <circle cx="105" cy="35" r="3"></circle>
+        <circle cx="135" cy="45" r="3"></circle>
+        <circle cx="160" cy="55" r="3"></circle>
+        <circle cx="165" cy="80" r="3"></circle>
       </g>
-      <text x="100" y="140" text-anchor="middle" fill="#fff" font-family="system-ui, sans-serif" font-size="28" font-weight="400">ámaxa</text>
+      <text
+        x="100"
+        y="140"
+        text-anchor="middle"
+        fill="#fff"
+        font-family="system-ui, sans-serif"
+        font-size="28"
+        font-weight="400">ámaxa</text
+      >
     </svg>
   </div>
-  <h1 class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-tight text-foreground">
-    Welcome.<br/>We Are Ámaxa.
+  <h1
+    class="text-foreground text-4xl leading-tight font-bold sm:text-5xl md:text-6xl lg:text-7xl"
+  >
+    Welcome.<br />We Are Ámaxa.
   </h1>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-start.astro
+++ b/apps/landing/src/components/pitch/slides/slide-start.astro
@@ -1,0 +1,34 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+---
+
+<PitchSlide id="start" title="Pitch / 2025" centered>
+  <div class="mb-12">
+    <svg class="w-[150px] h-[150px] md:w-[200px] md:h-[200px]" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="100" cy="100" r="98" fill="#000" stroke="#333" stroke-width="2"/>
+      <g stroke="#fff" stroke-width="1.5" stroke-linecap="round">
+        <line x1="35" y1="95" x2="55" y2="75"/>
+        <line x1="55" y1="75" x2="50" y2="50"/>
+        <line x1="50" y1="50" x2="75" y2="40"/>
+        <line x1="75" y1="40" x2="105" y2="35"/>
+        <line x1="105" y1="35" x2="135" y2="45"/>
+        <line x1="135" y1="45" x2="160" y2="55"/>
+        <line x1="160" y1="55" x2="165" y2="80"/>
+      </g>
+      <g fill="#fff">
+        <circle cx="35" cy="95" r="3"/>
+        <circle cx="55" cy="75" r="3"/>
+        <circle cx="50" cy="50" r="3"/>
+        <circle cx="75" cy="40" r="3"/>
+        <circle cx="105" cy="35" r="3"/>
+        <circle cx="135" cy="45" r="3"/>
+        <circle cx="160" cy="55" r="3"/>
+        <circle cx="165" cy="80" r="3"/>
+      </g>
+      <text x="100" y="140" text-anchor="middle" fill="#fff" font-family="system-ui, sans-serif" font-size="28" font-weight="400">ámaxa</text>
+    </svg>
+  </div>
+  <h1 class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-tight text-foreground">
+    Welcome.<br/>We Are Ámaxa.
+  </h1>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-stories.astro
+++ b/apps/landing/src/components/pitch/slides/slide-stories.astro
@@ -1,7 +1,8 @@
 ---
 import PitchSlide from "../pitch-slide.astro";
 
-const placeholderImage = "https://b47pkz22xs.ufs.sh/f/OxFTTzjZGToOQI4SoEOsmkEelahd1WSuvzRG6jICN9HqcOF3";
+const placeholderImage =
+  "https://b47pkz22xs.ufs.sh/f/OxFTTzjZGToOQI4SoEOsmkEelahd1WSuvzRG6jICN9HqcOF3";
 
 const stories = [
   {
@@ -28,29 +29,49 @@ const stories = [
 ---
 
 <PitchSlide id="stories" title="Student Stories" centered>
-  <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight text-foreground mb-4">
+  <h2
+    class="text-foreground mb-4 text-2xl leading-tight font-bold sm:text-3xl md:text-4xl"
+  >
     Real students. Real impact.
   </h2>
-  <p class="text-lg text-muted-foreground mb-10">Hear their stories.</p>
-  
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 w-full max-w-5xl">
-    {stories.map((story) => (
-      <figure class="group cursor-pointer">
-        <div class="relative aspect-[4/5] rounded-2xl overflow-hidden mb-3 ring-1 ring-border/20 hover:ring-2 hover:ring-brand-green/50 transition-all">
-          <img src={placeholderImage} alt={`${story.name}'s story`} class="size-full object-cover" />
-          <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
-          <div class="absolute inset-0 grid place-items-center">
-            <div class="size-14 rounded-full bg-black/30 backdrop-blur-sm border border-white/30 grid place-items-center group-hover:bg-brand-green group-hover:border-brand-green group-hover:scale-110 transition-all">
-              <svg class="size-6 text-white ml-1" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+  <p class="text-muted-foreground mb-10 text-lg">Hear their stories.</p>
+
+  <div
+    class="grid w-full max-w-5xl grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4"
+  >
+    {
+      stories.map((story) => (
+        <figure class="group cursor-pointer">
+          <div class="ring-border/20 hover:ring-brand-green/50 relative mb-3 aspect-[4/5] overflow-hidden rounded-2xl ring-1 transition-all hover:ring-2">
+            <img
+              src={placeholderImage}
+              alt={`${story.name}'s story`}
+              class="size-full object-cover"
+            />
+            <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+            <div class="absolute inset-0 grid place-items-center">
+              <div class="group-hover:bg-brand-green group-hover:border-brand-green grid size-14 place-items-center rounded-full border border-white/30 bg-black/30 backdrop-blur-sm transition-all group-hover:scale-110">
+                <svg
+                  class="ml-1 size-6 text-white"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
             </div>
+            <figcaption class="absolute inset-x-4 bottom-4">
+              <span class="text-xs tracking-wider text-white/80 uppercase">
+                {story.location}
+              </span>
+              <h3 class="text-xl font-bold text-white">{story.name}</h3>
+            </figcaption>
           </div>
-          <figcaption class="absolute bottom-4 inset-x-4">
-            <span class="text-xs text-white/80 uppercase tracking-wider">{story.location}</span>
-            <h3 class="text-xl font-bold text-white">{story.name}</h3>
-          </figcaption>
-        </div>
-        <p class="text-sm text-muted-foreground text-center">{story.description}</p>
-      </figure>
-    ))}
+          <p class="text-muted-foreground text-center text-sm">
+            {story.description}
+          </p>
+        </figure>
+      ))
+    }
   </div>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-stories.astro
+++ b/apps/landing/src/components/pitch/slides/slide-stories.astro
@@ -1,0 +1,56 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const placeholderImage = "https://b47pkz22xs.ufs.sh/f/OxFTTzjZGToOQI4SoEOsmkEelahd1WSuvzRG6jICN9HqcOF3";
+
+const stories = [
+  {
+    location: "UAE",
+    name: "Maitha",
+    description: "Cultural exchange programs with ISNAD Palestine",
+  },
+  {
+    location: "New Jersey",
+    name: "Katelyn",
+    description: "Led Mental Health First Aid workshops at her school",
+  },
+  {
+    location: "Georgia",
+    name: "Raima",
+    description: "Virtual Model UN conference for students in Liberia",
+  },
+  {
+    location: "Vietnam",
+    name: "An Nhi",
+    description: "Planted trees in US, Vietnam, Turkey—measured CO2 impact",
+  },
+];
+---
+
+<PitchSlide id="stories" title="Student Stories" centered>
+  <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold leading-tight text-foreground mb-4">
+    Real students. Real impact.
+  </h2>
+  <p class="text-lg text-muted-foreground mb-10">Hear their stories.</p>
+  
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 w-full max-w-5xl">
+    {stories.map((story) => (
+      <figure class="group cursor-pointer">
+        <div class="relative aspect-[4/5] rounded-2xl overflow-hidden mb-3 ring-1 ring-border/20 hover:ring-2 hover:ring-brand-green/50 transition-all">
+          <img src={placeholderImage} alt={`${story.name}'s story`} class="size-full object-cover" />
+          <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+          <div class="absolute inset-0 grid place-items-center">
+            <div class="size-14 rounded-full bg-black/30 backdrop-blur-sm border border-white/30 grid place-items-center group-hover:bg-brand-green group-hover:border-brand-green group-hover:scale-110 transition-all">
+              <svg class="size-6 text-white ml-1" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+            </div>
+          </div>
+          <figcaption class="absolute bottom-4 inset-x-4">
+            <span class="text-xs text-white/80 uppercase tracking-wider">{story.location}</span>
+            <h3 class="text-xl font-bold text-white">{story.name}</h3>
+          </figcaption>
+        </div>
+        <p class="text-sm text-muted-foreground text-center">{story.description}</p>
+      </figure>
+    ))}
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-traction.astro
+++ b/apps/landing/src/components/pitch/slides/slide-traction.astro
@@ -1,0 +1,74 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const stats = [
+  { number: "300+", label: "Applications" },
+  { number: "52+", label: "Countries" },
+  { number: "120+", label: "Students completed" },
+];
+
+const achievements = [
+  {
+    text: "Created <strong>Accessifyed</strong> platform for ISNAD Center in Palestine",
+    position: "top-[15%] left-[5%]",
+    rotate: "-2deg",
+  },
+  {
+    text: "Planted trees across <strong>Turkey, US, and UAE</strong>",
+    position: "top-[20%] right-[8%]",
+    rotate: "1deg",
+  },
+  {
+    text: "Raised <strong>$700</strong> for Gazans through student concerts",
+    position: "bottom-[28%] left-[3%]",
+    rotate: "1deg",
+  },
+  {
+    text: "Paid <strong>full year tuition for 7 students</strong> in Liberia",
+    position: "bottom-[35%] right-[5%]",
+    rotate: "-1deg",
+  },
+  {
+    text: "Raised <strong>$500</strong> for medical supplies in Ukraine",
+    position: "bottom-[15%] left-[25%]",
+    rotate: "2deg",
+  },
+];
+---
+
+<PitchSlide id="traction" title="2023 - 2025: Our Impact" centered>
+  <div class="flex flex-wrap justify-center gap-12 md:gap-16">
+    {stats.map((stat) => (
+      <div class="text-center">
+        <span class="block font-mono text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold text-foreground leading-none">
+          {stat.number}
+        </span>
+        <span class="text-sm text-muted-foreground uppercase tracking-wider">
+          {stat.label}
+        </span>
+      </div>
+    ))}
+  </div>
+
+  <!-- Scattered achievements -->
+  {achievements.map((achievement) => (
+    <div
+      class:list={[
+        "hidden md:block absolute max-w-[280px] bg-muted/40 backdrop-blur-sm border border-border/50 rounded-xl px-4 py-3 text-sm text-muted-foreground [&_strong]:text-brand-green [&_strong]:font-semibold shadow-sm",
+        achievement.position,
+      ]}
+      style={`transform: rotate(${achievement.rotate})`}
+      set:html={achievement.text}
+    />
+  ))}
+
+  <!-- Mobile: stacked achievements -->
+  <div class="md:hidden flex flex-col gap-3 mt-12 w-full max-w-md">
+    {achievements.map((achievement) => (
+      <div
+        class="bg-muted/40 border border-border/50 rounded-xl px-4 py-3 text-sm text-muted-foreground [&_strong]:text-brand-green [&_strong]:font-semibold"
+        set:html={achievement.text}
+      />
+    ))}
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-traction.astro
+++ b/apps/landing/src/components/pitch/slides/slide-traction.astro
@@ -38,37 +38,43 @@ const achievements = [
 
 <PitchSlide id="traction" title="2023 - 2025: Our Impact" centered>
   <div class="flex flex-wrap justify-center gap-12 md:gap-16">
-    {stats.map((stat) => (
-      <div class="text-center">
-        <span class="block font-mono text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold text-foreground leading-none">
-          {stat.number}
-        </span>
-        <span class="text-sm text-muted-foreground uppercase tracking-wider">
-          {stat.label}
-        </span>
-      </div>
-    ))}
+    {
+      stats.map((stat) => (
+        <div class="text-center">
+          <span class="text-foreground block font-mono text-5xl leading-none font-bold sm:text-6xl md:text-7xl lg:text-8xl">
+            {stat.number}
+          </span>
+          <span class="text-muted-foreground text-sm tracking-wider uppercase">
+            {stat.label}
+          </span>
+        </div>
+      ))
+    }
   </div>
 
   <!-- Scattered achievements -->
-  {achievements.map((achievement) => (
-    <div
-      class:list={[
-        "hidden md:block absolute max-w-[280px] bg-muted/40 backdrop-blur-sm border border-border/50 rounded-xl px-4 py-3 text-sm text-muted-foreground [&_strong]:text-brand-green [&_strong]:font-semibold shadow-sm",
-        achievement.position,
-      ]}
-      style={`transform: rotate(${achievement.rotate})`}
-      set:html={achievement.text}
-    />
-  ))}
-
-  <!-- Mobile: stacked achievements -->
-  <div class="md:hidden flex flex-col gap-3 mt-12 w-full max-w-md">
-    {achievements.map((achievement) => (
+  {
+    achievements.map((achievement) => (
       <div
-        class="bg-muted/40 border border-border/50 rounded-xl px-4 py-3 text-sm text-muted-foreground [&_strong]:text-brand-green [&_strong]:font-semibold"
+        class:list={[
+          "bg-muted/40 border-border/50 text-muted-foreground [&_strong]:text-brand-green absolute hidden max-w-[280px] rounded-xl border px-4 py-3 text-sm shadow-sm backdrop-blur-sm md:block [&_strong]:font-semibold",
+          achievement.position,
+        ]}
+        style={`transform: rotate(${achievement.rotate})`}
         set:html={achievement.text}
       />
-    ))}
+    ))
+  }
+
+  <!-- Mobile: stacked achievements -->
+  <div class="mt-12 flex w-full max-w-md flex-col gap-3 md:hidden">
+    {
+      achievements.map((achievement) => (
+        <div
+          class="bg-muted/40 border-border/50 text-muted-foreground [&_strong]:text-brand-green rounded-xl border px-4 py-3 text-sm [&_strong]:font-semibold"
+          set:html={achievement.text}
+        />
+      ))
+    }
   </div>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-vision.astro
+++ b/apps/landing/src/components/pitch/slides/slide-vision.astro
@@ -1,0 +1,50 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+
+const roadmap = [
+  { label: "University Students", status: "2026" },
+  { label: "Ámaxa Research", status: "2026" },
+  { label: "Global Community", status: "Ongoing" },
+];
+---
+
+<PitchSlide id="vision" title="2026 & Beyond" centered>
+  <p class="text-sm uppercase tracking-widest text-brand-green mb-4">The Future</p>
+  <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-foreground mb-6 max-w-3xl">
+    How can we plant more seeds?
+  </h2>
+  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-xl">
+    We're just getting started. Here's what's next.
+  </p>
+
+  <div class="flex flex-col sm:flex-row items-center gap-4 sm:gap-8 mb-16">
+    {roadmap.map((item, i) => (
+      <div class="flex items-center gap-4 sm:gap-8">
+        <div class="text-center">
+          <span class="block text-xs text-brand-green font-medium mb-1">{item.status}</span>
+          <span class="text-base sm:text-lg font-semibold text-foreground">{item.label}</span>
+        </div>
+       
+      </div>
+    ))}
+  </div>
+
+  <div class="flex flex-col sm:flex-row items-center gap-4">
+    <a
+      href="/pathways"
+      class="inline-flex items-center justify-center bg-brand-green text-black font-semibold text-base px-8 py-4 rounded-full transition-all hover:bg-brand-green/90 hover:scale-105"
+    >
+      Explore Pathways
+    </a>
+    <a
+      href="/apply"
+      class="inline-flex items-center justify-center border border-border text-foreground font-medium text-base px-8 py-4 rounded-full transition-all hover:bg-muted"
+    >
+      Apply Now →
+    </a>
+  </div>
+
+  <p class="mt-16 text-sm text-muted-foreground">
+    Questions? <a href="mailto:lauren@amaxaimpact.org" class="text-brand-green hover:underline">lauren@amaxaimpact.org</a>
+  </p>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-vision.astro
+++ b/apps/landing/src/components/pitch/slides/slide-vision.astro
@@ -9,42 +9,54 @@ const roadmap = [
 ---
 
 <PitchSlide id="vision" title="2026 & Beyond" centered>
-  <p class="text-sm uppercase tracking-widest text-brand-green mb-4">The Future</p>
-  <h2 class="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-foreground mb-6 max-w-3xl">
+  <p class="text-brand-green mb-4 text-sm tracking-widest uppercase">
+    The Future
+  </p>
+  <h2
+    class="text-foreground mb-6 max-w-3xl text-3xl leading-tight font-bold sm:text-4xl md:text-5xl lg:text-6xl"
+  >
     How can we plant more seeds?
   </h2>
-  <p class="text-lg sm:text-xl text-muted-foreground mb-12 max-w-xl">
+  <p class="text-muted-foreground mb-12 max-w-xl text-lg sm:text-xl">
     We're just getting started. Here's what's next.
   </p>
 
-  <div class="flex flex-col sm:flex-row items-center gap-4 sm:gap-8 mb-16">
-    {roadmap.map((item, i) => (
-      <div class="flex items-center gap-4 sm:gap-8">
-        <div class="text-center">
-          <span class="block text-xs text-brand-green font-medium mb-1">{item.status}</span>
-          <span class="text-base sm:text-lg font-semibold text-foreground">{item.label}</span>
+  <div class="mb-16 flex flex-col items-center gap-4 sm:flex-row sm:gap-8">
+    {
+      roadmap.map((item, i) => (
+        <div class="flex items-center gap-4 sm:gap-8">
+          <div class="text-center">
+            <span class="text-brand-green mb-1 block text-xs font-medium">
+              {item.status}
+            </span>
+            <span class="text-foreground text-base font-semibold sm:text-lg">
+              {item.label}
+            </span>
+          </div>
         </div>
-       
-      </div>
-    ))}
+      ))
+    }
   </div>
 
-  <div class="flex flex-col sm:flex-row items-center gap-4">
+  <div class="flex flex-col items-center gap-4 sm:flex-row">
     <a
       href="/pathways"
-      class="inline-flex items-center justify-center bg-brand-green text-black font-semibold text-base px-8 py-4 rounded-full transition-all hover:bg-brand-green/90 hover:scale-105"
+      class="bg-brand-green hover:bg-brand-green/90 inline-flex items-center justify-center rounded-full px-8 py-4 text-base font-semibold text-black transition-all hover:scale-105"
     >
       Explore Pathways
     </a>
     <a
       href="/apply"
-      class="inline-flex items-center justify-center border border-border text-foreground font-medium text-base px-8 py-4 rounded-full transition-all hover:bg-muted"
+      class="border-border text-foreground hover:bg-muted inline-flex items-center justify-center rounded-full border px-8 py-4 text-base font-medium transition-all"
     >
       Apply Now →
     </a>
   </div>
 
-  <p class="mt-16 text-sm text-muted-foreground">
-    Questions? <a href="mailto:lauren@amaxaimpact.org" class="text-brand-green hover:underline">lauren@amaxaimpact.org</a>
+  <p class="text-muted-foreground mt-16 text-sm">
+    Questions? <a
+      href="mailto:lauren@amaxaimpact.org"
+      class="text-brand-green hover:underline">lauren@amaxaimpact.org</a
+    >
   </p>
 </PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-what-we-do.astro
+++ b/apps/landing/src/components/pitch/slides/slide-what-we-do.astro
@@ -1,0 +1,17 @@
+---
+import PitchSlide from "../pitch-slide.astro";
+---
+
+<PitchSlide id="what-we-do" title="What We Do" centered>
+  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-6 max-w-4xl">
+    We connect people to grassroots organizations and initiatives doing community-based work.
+  </h2>
+  <p class="text-xl sm:text-2xl text-brand-green mb-8">
+    Human rights. Education. Equity. And more.
+  </p>
+  <div class="bg-card border border-border rounded-xl p-6 max-w-xl">
+    <p class="text-lg text-muted-foreground">
+      We help them contribute meaningfully through <strong class="text-foreground">fully remote programs</strong>.
+    </p>
+  </div>
+</PitchSlide>

--- a/apps/landing/src/components/pitch/slides/slide-what-we-do.astro
+++ b/apps/landing/src/components/pitch/slides/slide-what-we-do.astro
@@ -3,15 +3,20 @@ import PitchSlide from "../pitch-slide.astro";
 ---
 
 <PitchSlide id="what-we-do" title="What We Do" centered>
-  <h2 class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-foreground mb-6 max-w-4xl">
-    We connect people to grassroots organizations and initiatives doing community-based work.
+  <h2
+    class="text-foreground mb-6 max-w-4xl text-2xl leading-tight font-bold sm:text-3xl md:text-4xl lg:text-5xl"
+  >
+    We connect people to grassroots organizations and initiatives doing
+    community-based work.
   </h2>
-  <p class="text-xl sm:text-2xl text-brand-green mb-8">
+  <p class="text-brand-green mb-8 text-xl sm:text-2xl">
     Human rights. Education. Equity. And more.
   </p>
-  <div class="bg-card border border-border rounded-xl p-6 max-w-xl">
-    <p class="text-lg text-muted-foreground">
-      We help them contribute meaningfully through <strong class="text-foreground">fully remote programs</strong>.
+  <div class="bg-card border-border max-w-xl rounded-xl border p-6">
+    <p class="text-muted-foreground text-lg">
+      We help them contribute meaningfully through <strong
+        class="text-foreground">fully remote programs</strong
+      >.
     </p>
   </div>
 </PitchSlide>

--- a/apps/landing/src/layouts/pitch-layout.astro
+++ b/apps/landing/src/layouts/pitch-layout.astro
@@ -1,0 +1,43 @@
+---
+import JsonLd from "@/components/json-ld.astro";
+import Posthog from "@/components/posthog.astro";
+import SEO from "@/components/seo.astro";
+
+import "@/styles/global.css";
+
+interface Props {
+  title: string;
+  description: string;
+  image: string;
+  canonicalURL: string;
+}
+
+const { title, description, image, canonicalURL } = Astro.props;
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "amaxa",
+  url: "https://www.amaxaimpact.org",
+  logo: "https://www.amaxaimpact.org/icon.png",
+  description:
+    "An organization dedicated to removing barriers for anyone who wants to effect positive change in the world.",
+};
+---
+
+<html lang="en">
+  <head>
+    <SEO
+      title={title}
+      description={description}
+      image={image}
+      type="website"
+      canonicalURL={canonicalURL}
+    />
+    <JsonLd data={organizationSchema} />
+    <Posthog />
+  </head>
+  <body class="bg-background text-foreground m-0 min-h-screen">
+    <slot />
+  </body>
+</html>

--- a/apps/landing/src/pages/who-are-we.astro
+++ b/apps/landing/src/pages/who-are-we.astro
@@ -1,0 +1,33 @@
+---
+
+import PitchLayout from "@/layouts/pitch-layout.astro";
+import { PitchCarousel } from "@/components/pitch/pitch-carousel";
+import SlideStart from "@/components/pitch/slides/slide-start.astro";
+import SlideWhatWeDo from "@/components/pitch/slides/slide-what-we-do.astro";
+import SlideProblem from "@/components/pitch/slides/slide-problem.astro";
+import SlideSolution from "@/components/pitch/slides/slide-solution.astro";
+import SlidePartners from "@/components/pitch/slides/slide-partners.astro";
+import SlideTraction from "@/components/pitch/slides/slide-traction.astro";
+import SlideStories from "@/components/pitch/slides/slide-stories.astro";
+import SlideVision from "@/components/pitch/slides/slide-vision.astro";
+
+const TOTAL_SLIDES = 8;
+---
+
+<PitchLayout
+  title="Who Are We | Ámaxa"
+  description="We connect people to grassroots organizations doing community-based work in human rights, education, equity, and more."
+  image="https://b47pkz22xs.ufs.sh/f/OxFTTzjZGToOexh9L5yvrS3NH5LD0fGBOXwFydpiVbYzJMa1"
+  canonicalURL="https://www.amaxaimpact.org/who-are-we"
+>
+  <PitchCarousel client:load totalSlides={TOTAL_SLIDES}>
+    <SlideStart />
+    <SlideWhatWeDo />
+    <SlideProblem />
+    <SlideSolution />
+    <SlidePartners />
+    <SlideTraction />
+    <SlideStories />
+    <SlideVision />
+  </PitchCarousel>
+</PitchLayout>

--- a/apps/landing/src/pages/who-are-we.astro
+++ b/apps/landing/src/pages/who-are-we.astro
@@ -1,15 +1,14 @@
 ---
-
-import PitchLayout from "@/layouts/pitch-layout.astro";
 import { PitchCarousel } from "@/components/pitch/pitch-carousel";
-import SlideStart from "@/components/pitch/slides/slide-start.astro";
-import SlideWhatWeDo from "@/components/pitch/slides/slide-what-we-do.astro";
+import SlidePartners from "@/components/pitch/slides/slide-partners.astro";
 import SlideProblem from "@/components/pitch/slides/slide-problem.astro";
 import SlideSolution from "@/components/pitch/slides/slide-solution.astro";
-import SlidePartners from "@/components/pitch/slides/slide-partners.astro";
-import SlideTraction from "@/components/pitch/slides/slide-traction.astro";
+import SlideStart from "@/components/pitch/slides/slide-start.astro";
 import SlideStories from "@/components/pitch/slides/slide-stories.astro";
+import SlideTraction from "@/components/pitch/slides/slide-traction.astro";
 import SlideVision from "@/components/pitch/slides/slide-vision.astro";
+import SlideWhatWeDo from "@/components/pitch/slides/slide-what-we-do.astro";
+import PitchLayout from "@/layouts/pitch-layout.astro";
 
 const TOTAL_SLIDES = 8;
 ---


### PR DESCRIPTION
## What I Did

Added `/who-are-we` route - a horizontal carousel pitch deck ported from the Figma Dinner Presentation.

8 slides: Welcome → What We Do → Problem → Solution → Partners → Traction → Student Stories → Vision

Navigate with arrow buttons, keyboard, or dot indicators.

## QA

- [ ] Arrow buttons work (left/right)
- [ ] Keyboard arrows work
- [ ] Dot indicators jump to correct slide
- [ ] Mobile swipe works
- [ ] Slide counter shows correct numbers

## Note on Images/Videos

Student Stories slide uses placeholder images. I couldn't access the Figma file to copy/paste the actual photos and videos - will need someone with edit access to export those assets.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Who Are We?" page with an interactive eight-slide carousel presentation.
  * Carousel: horizontal snap scrolling, smooth programmatic transitions, visible slide counter, keyboard (arrow) navigation, prev/next buttons, and dot-based navigation.
  * New slides covering overview, mission, challenges, solutions, partners, metrics, student stories, and future vision — with responsive, accessible layouts and controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->